### PR TITLE
Add delayqueue primitive and tenantstate limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2288,6 +2288,7 @@ dependencies = [
  "tar",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-util",
  "toml",
  "tower",
  "uuid",

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -213,7 +213,10 @@ impl Cli {
             .rt
             .eval_chunk(code, Some(name), Some(self.setup_data.global_table.clone()))?;
 
-        self.setup_data.rt.handle_error(chunk_fn.call(ctx))
+        self
+        .setup_data
+        .rt
+        .call_in_scheduler(chunk_fn, ctx).await
     }
 
     pub async fn setup_lua_vm(

--- a/crates/cli/src/provider/mod.rs
+++ b/crates/cli/src/provider/mod.rs
@@ -323,7 +323,7 @@ ORDER BY scope;
         let entries = if query == "%%" {
             // Fast path for querying all keys
             sqlx::query(
-                "SELECT id, key, value, created_at, last_updated_at, scopes, expires_at
+                "SELECT id, key, value, created_at, last_updated_at, scopes
                 FROM kv_v2
                 WHERE 
                 guild_id = $1 
@@ -337,7 +337,7 @@ ORDER BY scope;
             .map_err(|e| format!("Failed to get key: {e}"))?
         } else {
             sqlx::query(
-                "SELECT id, key, value, created_at, last_updated_at, scopes, expires_at
+                "SELECT id, key, value, created_at, last_updated_at, scopes
                 FROM kv_v2
                 WHERE 
                 guild_id = $1 

--- a/crates/cli/src/provider/mod.rs
+++ b/crates/cli/src/provider/mod.rs
@@ -787,7 +787,7 @@ mod _runtimeprovider {
     pub struct TenantState {
         pub events: Vec<String>,
         pub banned: bool,
-        pub flags: u32,
+        pub data: serde_json::Value,
     }
 }
 
@@ -809,13 +809,13 @@ impl RuntimeProvider for CliRuntimeProvider {
             return Ok(runtime_ir::TenantState {
                 events: v.events,
                 banned: v.banned,
-                flags: v.flags,
+                data: v.data,
             });
         }
         return Ok(runtime_ir::TenantState {
             events: vec!["INTERACTION_CREATE".to_string()],
             banned: false,
-            flags: 0,
+            data: serde_json::Value::Null,
         });
     }
 
@@ -823,7 +823,7 @@ impl RuntimeProvider for CliRuntimeProvider {
         let v = serde_json::to_vec(&_runtimeprovider::TenantState {
             events: state.events,
             banned: state.banned,
-            flags: state.flags,
+            data: state.data,
         })?;
         self.file_storage_provider.save_file(&["tenantstate".to_string()], "0", &v).await?;
         Ok(())

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -11,6 +11,7 @@ log = "0.4"
 extract_map = { version = "0.3", features = ["serde"] }
 indexmap = { version = "2", features = ["serde"] }
 tokio = { version = "1" }
+tokio-util = { version = "0.7", features = ["time"] }
 arrayvec = "0.7"
 small-fixed-array = "0.4"
 reqwest = { version = "0.12" }

--- a/crates/runtime/src/core/channel.rs
+++ b/crates/runtime/src/core/channel.rs
@@ -161,6 +161,10 @@ impl LuaUserData for DelayChannel {
         methods.add_scheduler_async_method("next", async move |_, this, ()| {
             this.next().await
         });
+
+        methods.add_meta_method(LuaMetaMethod::Len, |_, this, _: ()| {
+            Ok(this.queue.try_borrow().map_err(LuaError::external)?.len())
+        });
     }
 }
 

--- a/crates/runtime/src/core/datetime.rs
+++ b/crates/runtime/src/core/datetime.rs
@@ -1,5 +1,5 @@
 use super::typesext::I64;
-use std::str::FromStr;
+use std::{str::FromStr, time::Duration};
 
 use chrono::{Datelike, TimeZone, Timelike};
 use chrono_tz::OffsetComponents;
@@ -19,6 +19,19 @@ impl TimeDelta {
     pub fn from_secs(td: i64) -> Self {
         TimeDelta {
             timedelta: chrono::Duration::seconds(td),
+        }
+    }
+
+    pub const fn from_millis(td: i64) -> Self {
+        TimeDelta {
+            timedelta: chrono::Duration::milliseconds(td),
+        }
+    }
+
+    pub const fn from_std(td: Duration) -> Result<TimeDelta, chrono::OutOfRangeError> {
+        match chrono::Duration::from_std(td) {
+            Ok(x) => Ok(TimeDelta { timedelta: x }),
+            Err(e) => Err(e)
         }
     }
 }

--- a/crates/runtime/src/traits/ir/kv.rs
+++ b/crates/runtime/src/traits/ir/kv.rs
@@ -8,7 +8,4 @@ pub struct KvRecord {
     pub scopes: Vec<String>,
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
     pub last_updated_at: Option<chrono::DateTime<chrono::Utc>>,
-
-    /// Returns when the key will expire, if set.
-    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
 }

--- a/crates/runtime/src/traits/ir/runtime.rs
+++ b/crates/runtime/src/traits/ir/runtime.rs
@@ -2,6 +2,8 @@ use mluau::prelude::*;
 
 use crate::core::datetime::DateTime;
 
+const MAX_EVENTS: usize = 100;
+
 // Tenant State
 #[derive(Debug, Clone)]
 pub struct TenantState {
@@ -24,6 +26,16 @@ impl FromLua for TenantState {
         };
 
         let events: Vec<String> = table.get("events")?;
+
+        // Ensure we dont have too many events set (which signifies a app logic error)
+        if events.len() > MAX_EVENTS {
+            return Err(LuaError::FromLuaConversionError {
+                from: "table",
+                to: "TenantState".to_string(),
+                message: Some(format!("too many events set in tenant state (max {} allowed)", MAX_EVENTS)),
+            });
+        }
+
         let banned: bool = table.get("banned")?;
         let data: LuaValue = table.get("data")?;
 

--- a/crates/runtime/src/traits/ir/runtime.rs
+++ b/crates/runtime/src/traits/ir/runtime.rs
@@ -26,6 +26,30 @@ impl FromLua for TenantState {
         let events: Vec<String> = table.get("events")?;
         let banned: bool = table.get("banned")?;
         let data: LuaValue = table.get("data")?;
+
+        // Ensure data is either a Object or Nil
+        match data {
+            LuaValue::Table(ref t) => {
+                if t.metatable().is_none() {
+                    // OK
+                } else {
+                    return Err(LuaError::FromLuaConversionError {
+                        from: "table with metatable",
+                        to: "TenantState".to_string(),
+                        message: Some("data field must be an object/map with no metatable or nil".to_string()),
+                    });
+                }
+            },
+            LuaValue::Nil => {}
+            _ => {
+                return Err(LuaError::FromLuaConversionError {
+                    from: data.type_name(),
+                    to: "TenantState".to_string(),
+                    message: Some("data field must be an object/map with no metatable or nil".to_string()),
+                });
+            }
+        }
+
         let data = lua.from_value(data)?;
 
         Ok(TenantState {

--- a/crates/runtime/src/traits/ir/runtime.rs
+++ b/crates/runtime/src/traits/ir/runtime.rs
@@ -7,11 +7,11 @@ use crate::core::datetime::DateTime;
 pub struct TenantState {
     pub events: Vec<String>,
     pub banned: bool,
-    pub flags: u32,
+    pub data: serde_json::Value,
 }
 
 impl FromLua for TenantState {
-    fn from_lua(value: LuaValue, _lua: &Lua) -> LuaResult<Self> {
+    fn from_lua(value: LuaValue, lua: &Lua) -> LuaResult<Self> {
         let table = match value {
             LuaValue::Table(t) => t,
             _ => {
@@ -25,12 +25,13 @@ impl FromLua for TenantState {
 
         let events: Vec<String> = table.get("events")?;
         let banned: bool = table.get("banned")?;
-        let flags: u32 = table.get("flags")?;
+        let data: LuaValue = table.get("data")?;
+        let data = lua.from_value(data)?;
 
         Ok(TenantState {
             events,
             banned,
-            flags,
+            data,
         })
     }
 }
@@ -41,7 +42,7 @@ impl IntoLua for TenantState {
 
         table.set("events", self.events)?;
         table.set("banned", self.banned)?;
-        table.set("flags", self.flags)?;
+        table.set("data", lua.to_value(&self.data)?)?;
 
         // Note that we do not set tenant state to readonly as we may want to mutate it
 

--- a/crates/runtime/src/traits/kvprovider.rs
+++ b/crates/runtime/src/traits/kvprovider.rs
@@ -39,7 +39,6 @@ pub trait KVProvider: 'static + Clone {
         scopes: &[String],
         key: String,
         value: KhronosValue,
-        expires_at: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<(bool, String), crate::Error>;
 
     /// Set a record in the key-value store by ID which already exists in the database
@@ -49,22 +48,6 @@ pub trait KVProvider: 'static + Clone {
         &self,
         id: String,
         value: KhronosValue,
-        expires_at: Option<chrono::DateTime<chrono::Utc>>,
-    ) -> Result<(), crate::Error>;
-
-    /// Sets the expiry of a key in the key-value store
-    async fn set_expiry(
-        &self,
-        scopes: &[String],
-        key: String,
-        expires_at: Option<chrono::DateTime<chrono::Utc>>,
-    ) -> Result<(), crate::Error>;
-
-    /// Sets the expiry of a key in the key-value store by ID
-    async fn set_expiry_by_id(
-        &self,
-        id: String,
-        expires_at: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<(), crate::Error>;
 
     /// Delete a record from the key-value store.

--- a/delayqueuetest.luau
+++ b/delayqueuetest.luau
@@ -1,0 +1,9 @@
+local channel = require "@antiraid/channel" :: any
+local time = require "@antiraid/datetime" :: any
+local delayqueue = channel.DelayChannel()
+task.delay(2, function()
+    print("Adding to delay queue")
+    delayqueue:add("hello world", time.timedelta_seconds(2))
+end)
+local v = delayqueue:next()
+print(v)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a delay queue with async retrieval and cancellable handles for scheduled items.

* **Improvements**
  * Task execution now runs via the async scheduler.
  * Runtime state now uses structured JSON-like data.

* **Chores**
  * Added a timing utility dependency.

* **Tests**
  * Added a Lua test demonstrating delayed enqueue and retrieval.

* **Breaking Changes**
  * Key-value expiry support removed; public state shape changed (flags → data).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->